### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/kimandueric/7d0c4e8c-9baf-4cb1-bede-5deade811f03/4e5b0fe9-339d-4d35-ae82-4ddfad114b67/_apis/work/boardbadge/82346c86-0300-4043-9d33-80633748f0e7)](https://dev.azure.com/kimandueric/7d0c4e8c-9baf-4cb1-bede-5deade811f03/_boards/board/t/4e5b0fe9-339d-4d35-ae82-4ddfad114b67/Microsoft.RequirementCategory)
 # Labs
 Sample labs to test the implementation of micro-service architecture using different technologies and best practices in code development.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#3](https://dev.azure.com/kimandueric/7d0c4e8c-9baf-4cb1-bede-5deade811f03/_workitems/edit/3). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.